### PR TITLE
Server inbound handler performance

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -14,9 +14,9 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ServerInboundHandlerBenchmark {
 
-  private val MAX  = 10000
-  private val PAR  = 10
-  private val res  = ZIO.succeed(Response.text("Hello World!"))
+  private val MAX      = 10000
+  private val PAR      = 10
+  private val res      = ZIO.succeed(Response.text("Hello World!"))
   private val endPoint = "test"
   private val http     = Routes(Route.route(Method.GET / endPoint)(handler(res))).toHttpApp
 
@@ -30,7 +30,7 @@ class ServerInboundHandlerBenchmark {
 
   private val benchmarkZioParallel =
     (for {
-      port <- Server.install(http)
+      port   <- Server.install(http)
       client <- ZIO.service[Client]
       url    <- ZIO.fromEither(URL.decode(s"http://localhost:$port/$endPoint"))
       call = client.request(Request(url = url))
@@ -46,8 +46,6 @@ class ServerInboundHandlerBenchmark {
 
   @Benchmark
   def benchmarkAppParallel(): Unit = {
-    zio.Unsafe.unsafe(implicit u =>
-      zio.Runtime.default.unsafe.run(benchmarkZioParallel)
-    )
+    zio.Unsafe.unsafe(implicit u => zio.Runtime.default.unsafe.run(benchmarkZioParallel))
   }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -6,27 +6,48 @@ import zio.http._
 
 import java.util.concurrent.TimeUnit
 
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@Fork(value = 1)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ServerInboundHandlerBenchmark {
 
-  private val MAX      = 10000
-  private val PAR      = 10
-  private val res      = ZIO.succeed(Response.ok)
+  private val MAX  = 10000
+  private val PAR  = 10
+  private val res  = ZIO.succeed(Response.text("Hello World!"))
   private val endPoint = "test"
   private val http     = Routes(Route.route(Method.GET / endPoint)(handler(res))).toHttpApp
 
-  def benchmarkZioParallel(): Task[Unit] =
+//  private val benchmarkZio =
+//    (for {
+//      port <- Server.install(http)
+//      client <- ZIO.service[Client]
+//      url    <- ZIO.fromEither(URL.decode(s"http://localhost:$port/$endPoint"))
+//      _ <- client.request(Request(url = url)).repeatN(MAX)
+//    } yield ()).provide(Server.default, ZClient.default, zio.Scope.default)
+
+  private val benchmarkZioParallel =
     (for {
-      port   <- Server.install(http)
+      port <- Server.install(http)
       client <- ZIO.service[Client]
       url    <- ZIO.fromEither(URL.decode(s"http://localhost:$port/$endPoint"))
-      _      <- ZIO.foreachParDiscard((0 until PAR).toList)(_ => client.request(Request(url = url)).repeatN(MAX / PAR))
+      call = client.request(Request(url = url))
+      _ <- ZIO.collectAllParDiscard(List.fill(MAX)(call)).withParallelism(PAR)
     } yield ()).provide(Server.default, ZClient.default, zio.Scope.default)
+
+//  @Benchmark
+//  def benchmarkApp(): Unit = {
+//    zio.Unsafe.unsafe(implicit u =>
+//      zio.Runtime.default.unsafe.run(benchmarkZio)
+//    )
+//  }
 
   @Benchmark
   def benchmarkAppParallel(): Unit = {
-    zio.Unsafe.unsafe(implicit u => zio.Runtime.default.unsafe.run(benchmarkZioParallel()))
+    zio.Unsafe.unsafe(implicit u =>
+      zio.Runtime.default.unsafe.run(benchmarkZioParallel)
+    )
   }
 }

--- a/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -29,74 +29,73 @@ import io.netty.handler.codec.http.{DefaultHttpContent, LastHttpContent}
 
 object NettyBodyWriter {
 
-  def write(body: Body, ctx: ChannelHandlerContext): ZIO[Any, Throwable, Boolean] =
+  implicit private val unsafe: Unsafe = Unsafe.unsafe
+
+  def write(
+    runtime: NettyRuntime,
+    body: Body,
+    ctx: ChannelHandlerContext,
+  ): Boolean =
     body match {
       case body: ByteBufBody                  =>
-        ZIO.succeed {
-          ctx.write(body.byteBuf)
-          false
-        }
+        ctx.write(body.byteBuf)
+        false
       case body: FileBody                     =>
-        ZIO.succeed {
-          val file = body.file
-          // Write the content.
-          ctx.write(new DefaultFileRegion(file, 0, file.length()))
+        val file = body.file
+        // Write the content.
+        ctx.write(new DefaultFileRegion(file, 0, file.length()))
 
-          // Write the end marker.
-          ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-          true
-        }
+        // Write the end marker.
+        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+        true
       case AsyncBody(async, _, _)             =>
-        ZIO.attempt {
-          async(
-            new UnsafeAsync {
-              override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
-                val nettyMsg = message match {
-                  case b: ByteArray => Unpooled.wrappedBuffer(b.array)
-                  case other        => Unpooled.wrappedBuffer(other.toArray)
-                }
-                ctx.writeAndFlush(nettyMsg)
-                if (isLast) ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+        async(
+          new UnsafeAsync {
+            override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
+              val nettyMsg = message match {
+                case b: ByteArray => Unpooled.wrappedBuffer(b.array)
+                case other        => Unpooled.wrappedBuffer(other.toArray)
               }
+              ctx.writeAndFlush(nettyMsg)
+              if (isLast) ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+            }
 
-              override def fail(cause: Throwable): Unit =
-                ctx.fireExceptionCaught(cause)
-            },
-          )
-          true
-        }
+            override def fail(cause: Throwable): Unit =
+              ctx.fireExceptionCaught(cause)
+          },
+        )
+        true
       case AsciiStringBody(asciiString, _, _) =>
-        ZIO.attempt {
-          ctx.write(Unpooled.wrappedBuffer(asciiString.array()))
-          false
-        }
+        ctx.write(Unpooled.wrappedBuffer(asciiString.array()))
+        false
       case StreamBody(stream, _, _)           =>
-        stream.chunks
-          .runFoldZIO(Option.empty[Chunk[Byte]]) {
-            case (Some(previous), current) =>
-              NettyFutureExecutor.executed {
-                ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(previous.toArray)))
-              } *>
+        runtime.run(ctx, NettyRuntime.noopEnsuring)(
+          stream.chunks
+            .runFoldZIO(Option.empty[Chunk[Byte]]) {
+              case (Some(previous), current) =>
+                NettyFutureExecutor.executed {
+                  ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(previous.toArray)))
+                } *>
+                  ZIO.succeed(Some(current))
+              case (_, current)              =>
                 ZIO.succeed(Some(current))
-            case (_, current)              =>
-              ZIO.succeed(Some(current))
-          }
-          .flatMap { maybeLastChunk =>
-            // last chunk is handled separately to avoid fiber interrupt before EMPTY_LAST_CONTENT is sent
-            ZIO.attempt(
-              maybeLastChunk.foreach { lastChunk =>
-                ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(lastChunk.toArray)))
-              },
-            ) *>
-              NettyFutureExecutor.executed {
-                ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-              }.as(true)
-          }
+            }
+            .flatMap { maybeLastChunk =>
+              // last chunk is handled separately to avoid fiber interrupt before EMPTY_LAST_CONTENT is sent
+              ZIO.attempt(
+                maybeLastChunk.foreach { lastChunk =>
+                  ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(lastChunk.toArray)))
+                },
+              ) *>
+                NettyFutureExecutor.executed {
+                  ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+                }
+            },
+        )
+        true
       case ChunkBody(data, _, _)              =>
-        ZIO.succeed {
-          ctx.write(Unpooled.wrappedBuffer(data.toArray))
-          false
-        }
-      case EmptyBody                          => ZIO.succeed(false)
+        ctx.write(Unpooled.wrappedBuffer(data.toArray))
+        false
+      case EmptyBody                          => false
     }
 }

--- a/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
@@ -54,9 +54,7 @@ final class ClientInboundHandler(
         ctx.writeAndFlush(fullRequest)
       case _: HttpRequest               =>
         ctx.write(jReq)
-        rtm.run(ctx, NettyRuntime.noopEnsuring) {
-          NettyBodyWriter.write(req.body, ctx).unit
-        }(Unsafe.unsafe, trace)
+        NettyBodyWriter.write(rtm, req.body, ctx)
         ctx.flush(): Unit
     }
   }

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -184,28 +184,20 @@ private[zio] final case class ServerInboundHandler(
     response: Response,
     jRequest: HttpRequest,
     time: ServerTime,
-  ): Task[Unit] = {
-    for {
-      _ <-
-        if (response.isWebSocket) ZIO.attempt(upgradeToWebSocket(ctx, jRequest, response, runtime))
+  ): Unit =
+    if (response.isWebSocket) upgradeToWebSocket(ctx, jRequest, response, runtime)
+    else {
+      val jResponse = NettyResponseEncoder.encode(ctx, response, runtime)
+      setServerTime(time, response, jResponse)
+      ctx.writeAndFlush(jResponse)
+      val flushed   =
+        if (!jResponse.isInstanceOf[FullHttpResponse])
+          NettyBodyWriter.write(runtime, response.body, ctx)
         else
-          for {
-            jResponse <- ZIO.attempt {
-              val jResponse = NettyResponseEncoder.encode(ctx, response, runtime)
-              setServerTime(time, response, jResponse)
-              ctx.writeAndFlush(jResponse)
-              jResponse
-            }
-            flushed   <-
-              if (!jResponse.isInstanceOf[FullHttpResponse])
-                NettyBodyWriter
-                  .write(response.body, ctx)
-              else
-                ZIO.succeed(true)
-            _         <- ZIO.attempt(ctx.flush()).when(!flushed)
-          } yield ()
-    } yield ()
-  }
+          true
+      if (!flushed)
+        ctx.flush()
+    }
 
   private def attemptImmediateWrite(
     ctx: ChannelHandlerContext,
@@ -317,11 +309,9 @@ private[zio] final case class ServerInboundHandler(
   }
 
   private def writeNotFound(ctx: ChannelHandlerContext, jReq: HttpRequest): Unit = {
-    runtime.run(ctx, () => ()) {
-      val response = HttpError.NotFound(jReq.uri()).toResponse
-      val done = attemptFastWrite(ctx, response, time)
-      attemptFullWrite(ctx, response, jReq, time).unless(done)
-    }
+    val response = HttpError.NotFound(jReq.uri()).toResponse
+    if (!attemptFastWrite(ctx, response, time))
+      attemptFullWrite(ctx, response, jReq, time)
   }
 
   private def writeResponse(
@@ -346,10 +336,11 @@ private[zio] final case class ServerInboundHandler(
         }
         _        <-
           if (response ne null) {
-            (for {
-              done <- ZIO.attempt(attemptFastWrite(ctx, response, time))
-              _    <- attemptFullWrite(ctx, response, jReq, time).unless(done)
-            } yield ()).catchSomeCause { case cause =>
+            ZIO.attempt {
+              if (!attemptFastWrite(ctx, response, time)) {
+                attemptFullWrite(ctx, response, jReq, time)
+              }
+            }.catchSomeCause { case cause =>
               ZIO.attempt(
                 attemptFastWrite(ctx, withDefaultErrorResponse(cause.squash).freeze, time),
               )


### PR DESCRIPTION
I do not see any perf improvement. Maybe it should be run with more iterations..

I removed effects from `NettyBodyWriter` only the `StreamBody` needed to have the effect because of the stream.
Also some effects (flatMaps) were removed from `ServerInboundHandler`. I think it should be ok because code is `writeResponse` is still wrapped in the attempt, but rather consult it with John. 